### PR TITLE
Bug with mPDF 6

### DIFF
--- a/classes/Kohana/Mpdf.php
+++ b/classes/Kohana/Mpdf.php
@@ -213,7 +213,8 @@ class Kohana_MPDF
     public function setDataToPdf($rhtml)
     {
         //default preferences
-        $this->mpdf->SetAutoFont(AUTOFONT_ALL);
+        //$this->mpdf->SetAutoFont(AUTOFONT_ALL);
+		$this->mpdf->autoScriptToLang = true;
         $this->mpdf->list_indent_first_level = 0;
 
         // Render the HTML to a PDF


### PR DESCRIPTION
Shows this error if the SetAutoFont is set.
mPDF error: function SetAutoFont is depracated as of mPDF 6. Please use autoScriptToLang instead. See config.php
Now is working perfectly.

Also, you should create an init.php in the root of the module to load de vendor classes.
### init.php

```
<?php defined('SYSPATH') or die('No direct script access.');
require_once Kohana::find_file('vendor', 'mpdf60/mpdf');
```

And also, create a vendor folder with the code from vendor's provider
